### PR TITLE
Reverted changes to toolbar relative positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@blackbaud/skyux": "2.43.0",
-    "@blackbaud/skyux-builder": "1.32.1",
+    "@blackbaud/skyux": "2.47.0",
+    "@blackbaud/skyux-builder": "1.33.1",
     "@skyux-sdk/builder-plugin-skyux": "1.0.0"
   }
 }

--- a/src/app/public/modules/toolbar/toolbar-section.component.scss
+++ b/src/app/public/modules/toolbar/toolbar-section.component.scss
@@ -6,11 +6,11 @@
   padding: $sky-padding-half $sky-padding 0;
   min-height: $sky-toolbar-min-height;
   align-items: center;
+  position: relative;
 }
 
 .sky-toolbar-section-items {
   display: flex;
   flex-wrap: wrap;
-  position: relative;
   align-items: center;
 }

--- a/src/app/public/modules/toolbar/toolbar.component.scss
+++ b/src/app/public/modules/toolbar/toolbar.component.scss
@@ -26,6 +26,5 @@
 .sky-toolbar-items {
   display: flex;
   flex-wrap: wrap;
-  position: relative;
   align-items: center;
 }


### PR DESCRIPTION
Addresses blackbaud/skyux-select-field#23

UX note: we noticed the top/bottom padding was off (and always has been). I've filed a separate issue to track this, as those changes are in a different repo: https://github.com/blackbaud/skyux-lookup/issues/19
