### PR TITLE
Deprecate dock service

### DIFF
--- a/src/app/docs/dock/dock-docs.component.html
+++ b/src/app/docs/dock/dock-docs.component.html
@@ -1,9 +1,0 @@
-<sky-docs-demo-page
-  moduleName="SkyDockModule"
-  moduleSourceCodePath="src/app/public/modules/dock/"
-  pageTitle="Dock"
->
-  <sky-docs-demo-page-summary>
-    The dock module attaches (or "docks") elements to specific areas of the screen.
-  </sky-docs-demo-page-summary>
-</sky-docs-demo-page>

--- a/src/app/docs/dock/dock-docs.component.ts
+++ b/src/app/docs/dock/dock-docs.component.ts
@@ -1,9 +1,0 @@
-import {
-  Component
-} from '@angular/core';
-
-@Component({
-  selector: 'app-dock-docs',
-  templateUrl: './dock-docs.component.html'
-})
-export class DockDocsComponent { }

--- a/src/app/docs/dock/index.html
+++ b/src/app/docs/dock/index.html
@@ -1,2 +1,0 @@
-<app-dock-docs>
-</app-dock-docs>

--- a/src/app/public/modules/dock/dock-item-config.ts
+++ b/src/app/public/modules/dock/dock-item-config.ts
@@ -4,6 +4,7 @@ import {
 
 /**
  * Configuration to be used by the docking action.
+ * @deprecated Use `SkyDockItemConfig` from `@skyux/core` instead.
  */
 export interface SkyDockItemConfig {
 

--- a/src/app/public/modules/dock/dock-item.ts
+++ b/src/app/public/modules/dock/dock-item.ts
@@ -5,6 +5,7 @@ import {
 
 /**
  * Represents a single item added to the dock.
+ * @deprecated Use `SkyDockItem` from `@skyux/core` instead.
  */
 export class SkyDockItem<T> {
 

--- a/src/app/public/modules/dock/dock.module.ts
+++ b/src/app/public/modules/dock/dock.module.ts
@@ -19,6 +19,9 @@ import {
   SkyDockService
 } from './dock.service';
 
+/**
+ * @deprecated Use `SkyDockModule` from `@skyux/core` instead.
+ */
 @NgModule({
   imports: [
     CommonModule,

--- a/src/app/public/modules/dock/dock.service.ts
+++ b/src/app/public/modules/dock/dock.service.ts
@@ -26,6 +26,7 @@ import {
 
 /**
  * This service docks components to specific areas on the page.
+ * @deprecated Use `SkyDockService` from `@skyux/core` instead.
  */
 @Injectable()
 export class SkyDockService {


### PR DESCRIPTION
Deprecating the dock service/module. Migrating it to `@skyux/core`: https://github.com/blackbaud/skyux-core/pull/125