### PR TITLE
Doc tweaks for back to top component

### DIFF
--- a/src/app/docs/back-to-top/back-to-top-docs.component.html
+++ b/src/app/docs/back-to-top/back-to-top-docs.component.html
@@ -4,16 +4,16 @@
   pageTitle="Back to top"
 >
   <sky-docs-demo-page-summary>
-    The back to top directive creates a button and associates it with an element on the page. When users scroll away from the element, the button appears in the bottom left of the page, and users can click the button to return to that element.
+    The back to top button in the bottom left of the page returns users to an element after they scroll away from it.
   </sky-docs-demo-page-summary>
 
-  <sky-docs-demo>
+<!--  <sky-docs-demo>
     <div
       class="sky-text-info sky-margin-stacked-content-section"
     >
       We are creating a back to top component demo for this section.
     </div>
-  </sky-docs-demo>
+  </sky-docs-demo> -->
 
   <sky-docs-code-examples
     [packageDependencies]="{

--- a/src/app/public/modules/back-to-top/back-to-top.directive.ts
+++ b/src/app/public/modules/back-to-top/back-to-top.directive.ts
@@ -40,8 +40,8 @@ import {
 } from './models/back-to-top-options';
 
 /**
- * Associates a button with an element on the page and displays a button
- * to return to that element after users scroll away from it.
+ * Associates a button with an element on the page and displays that button
+ * to return to the element after users scroll away.
  */
 @Directive({
   selector: '[skyBackToTop]',
@@ -51,6 +51,9 @@ import {
 })
 export class SkyBackToTopDirective implements AfterViewInit, OnDestroy {
 
+  /**
+   * Specifies configuration options for the back to top component.
+   */
   @Input()
   public set skyBackToTop(value: SkyBackToTopOptions) {
     this.buttonHidden = !!value?.buttonHidden;
@@ -59,7 +62,8 @@ export class SkyBackToTopDirective implements AfterViewInit, OnDestroy {
   }
 
   /**
-   * Provides an observable to send commands to the back to top that respect the `SkyBackToTopMessage` type.
+   * Provides an observable to send commands to the back to top component.
+   * The commands respect the `SkyBackToTopMessage` type.
    */
   @Input()
   public set skyBackToTopMessageStream(value: Subject<SkyBackToTopMessage>) {

--- a/src/app/public/modules/back-to-top/models/back-to-top-message.ts
+++ b/src/app/public/modules/back-to-top/models/back-to-top-message.ts
@@ -3,12 +3,12 @@ import {
 } from './back-to-top-message-type';
 
 /**
- * Specifies messages to be sent to the back to top component.
+ * Specifies messages to send to the back to top component.
  */
 export interface SkyBackToTopMessage {
 
   /**
-   * The type of message to send.
+   * Specifies the type of message to send.
    */
   type?: SkyBackToTopMessageType;
 }

--- a/src/app/public/modules/back-to-top/models/back-to-top-options.ts
+++ b/src/app/public/modules/back-to-top/models/back-to-top-options.ts
@@ -4,7 +4,8 @@
 export interface SkyBackToTopOptions {
 
   /**
-   * Indicates if the "back to top" button should be hidden in the UI.
+   * Indicates whether to hide the back to top button.
+   * @default false
    */
   buttonHidden?: boolean;
 }


### PR DESCRIPTION
Tweaks as discussed with Erika for new dev properties, plus tightened up summary to follow Design's preferred option for short summaries with no implementation details. Also, hide the demo note after talking with Alex.