### PR TITLE
Update gutter descriptions to fix modern theme discrepancy

### DIFF
--- a/src/app/public/modules/fluid-grid/fluid-grid-gutter-size.ts
+++ b/src/app/public/modules/fluid-grid/fluid-grid-gutter-size.ts
@@ -1,14 +1,14 @@
 export enum SkyFluidGridGutterSize {
   /**
-   * Specifies a 10px gutter.
+   * Specifies a small gutter.
    */
   Small,
   /**
-   * Specifies a 20px gutter.
+   * Specifies a medium gutter.
    */
   Medium,
   /**
-   * Specifies a 30px gutter.
+   * Specifies a large gutter.
    */
   Large
 }


### PR DESCRIPTION
Gutter widths are different in modern and default themes, so removing the values to avoid incorrect values in either place.