### PR TITLE
Turned off view encapsulation for action button

### DIFF
--- a/src/app/public/modules/action-button/action-button-container.component.scss
+++ b/src/app/public/modules/action-button/action-button-container.component.scss
@@ -7,10 +7,6 @@
 }
 
 .sky-action-button-container {
-  display: flex;
-  flex-flow: row wrap;
-  padding: $sky-padding 0;
-
   sky-action-button {
     display: block;
   }
@@ -24,29 +20,30 @@
 }
 
 @include sky-host-responsive-container-xs-min(false) {
-  sky-action-button {
-    margin: $sky-margin-double 0;
-  }
+  .sky-action-button-container {
+    display: block;
+    padding: 0;
 
-  .sky-theme-modern {
     sky-action-button {
-      margin: 0 7.5px 15px;
+      margin: $sky-margin-double 0;
     }
   }
 }
 
 @include sky-host-responsive-container-sm-min(false) {
-  sky-action-button {
-    margin: $sky-margin 0;
+  .sky-action-button-container {
+    display: flex;
+    flex-flow: row wrap;
+    padding: $sky-padding 0;
+
+    sky-action-button {
+      margin: $sky-margin 0;
+    }
   }
 }
 
 .sky-theme-modern {
   .sky-action-button-container {
-    display: flex;
-    padding: 0 7.5px;
-    margin: 0 auto;
-
     &.sky-action-button-container-sm {
       max-width: 476px;
     }
@@ -73,4 +70,18 @@
       margin: 0;
     }
   }
+
+  @include sky-host-responsive-container-xs-min(false) {
+    .sky-action-button-container {
+      display: flex;
+      flex-flow: row wrap;
+      padding: 0 7.5px;
+      margin: 0 auto;
+
+      sky-action-button {
+        margin: 0 7.5px 15px;
+      }
+    }
+  }
 }
+

--- a/src/app/public/modules/action-button/action-button-container.component.scss
+++ b/src/app/public/modules/action-button/action-button-container.component.scss
@@ -6,19 +6,44 @@
   display: block;
 }
 
-@include sky-host-responsive-container-sm-min() {
-  .sky-action-button-container {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: stretch;
-    padding: $sky-padding 0;
+.sky-action-button-container {
+  display: flex;
+  flex-flow: row wrap;
+  padding: $sky-padding 0;
+
+  sky-action-button {
+    display: block;
+  }
+
+  .sky-action-button {
+    height: 100%;
+    min-width: 236px;
+    margin-left: $sky-margin;
+    margin-right: $sky-margin;
   }
 }
 
-@include sky-theme-modern {
+@include sky-host-responsive-container-xs-min(false) {
+  sky-action-button {
+    margin: $sky-margin-double 0;
+  }
+
+  .sky-theme-modern {
+    sky-action-button {
+      margin: 0 7.5px 15px;
+    }
+  }
+}
+
+@include sky-host-responsive-container-sm-min(false) {
+  sky-action-button {
+    margin: $sky-margin 0;
+  }
+}
+
+.sky-theme-modern {
   .sky-action-button-container {
     display: flex;
-    flex-flow: row wrap;
     padding: 0 7.5px;
     margin: 0 auto;
 
@@ -41,6 +66,11 @@
     &.sky-action-button-container-align-left {
       justify-content: flex-start;
     }
+
+    .sky-action-button {
+      height: auto;
+      min-width: auto;
+      margin: 0;
+    }
   }
 }
-

--- a/src/app/public/modules/action-button/action-button-container.component.scss
+++ b/src/app/public/modules/action-button/action-button-container.component.scss
@@ -80,6 +80,7 @@
 
       sky-action-button {
         margin: 0 7.5px 15px;
+        flex: 0 1 446px;
       }
     }
   }

--- a/src/app/public/modules/action-button/action-button-container.component.ts
+++ b/src/app/public/modules/action-button/action-button-container.component.ts
@@ -5,7 +5,8 @@ import {
   HostListener,
   Input,
   OnInit,
-  ViewChild
+  ViewChild,
+  ViewEncapsulation
 } from '@angular/core';
 
 import {
@@ -39,7 +40,8 @@ import {
 @Component({
   selector: 'sky-action-button-container',
   styleUrls: ['./action-button-container.component.scss'],
-  templateUrl: './action-button-container.component.html'
+  templateUrl: './action-button-container.component.html',
+  encapsulation: ViewEncapsulation.None
 })
 export class SkyActionButtonContainerComponent implements OnInit {
 

--- a/src/app/public/modules/action-button/action-button.component.scss
+++ b/src/app/public/modules/action-button/action-button.component.scss
@@ -6,7 +6,7 @@
   @include sky-border(dark, top, bottom, left, right);
   cursor: pointer;
   text-align: center;
-  text-decoration: none;
+  text-decoration: none !important;
   display: block;
 
   &:hover {

--- a/src/app/public/modules/action-button/action-button.component.scss
+++ b/src/app/public/modules/action-button/action-button.component.scss
@@ -2,27 +2,6 @@
 @import "~@skyux/theme/scss/_compat/mixins";
 @import "~@skyux/theme/scss/themes/modern/_compat/_mixins";
 
-:host-context(.sky-action-button-container) {
-  & {
-    display: block;
-  }
-
-  .sky-action-button {
-    height: 100%;
-    min-width: 236px;
-    margin-left: $sky-margin;
-    margin-right: $sky-margin;
-  }
-}
-
-:host-context(.sky-theme-modern .sky-action-button-container) {
-  .sky-action-button {
-    height: auto;
-    min-width: auto;
-    margin: 0;
-  }
-}
-
 .sky-action-button {
   @include sky-border(dark, top, bottom, left, right);
   cursor: pointer;
@@ -40,20 +19,7 @@
   justify-content: center;
 }
 
-@include sky-host-responsive-container-xs-min() {
-
-  :host-context(.sky-action-button-container) {
-    & {
-      margin: $sky-margin-double 0;
-    }
-  }
-
-  :host-context(.sky-theme-modern .sky-action-button-container) {
-    & {
-      margin: 0 7.5px 15px;
-    }
-  }
-
+@include sky-host-responsive-container-xs-min(false) {
   .sky-action-button {
     padding: $sky-padding-double $sky-padding-double $sky-padding-triple;
     margin: 0 $sky-margin-plus-half;
@@ -64,19 +30,7 @@
   }
 }
 
-@include sky-host-responsive-container-sm-min() {
-  :host-context(.sky-action-button-container) {
-    & {
-      margin: $sky-margin 0;
-    }
-  }
-
-  :host-context(.sky-theme-modern .sky-action-button-container) {
-    & {
-      margin: 0 7.5px 15px;
-    }
-  }
-
+@include sky-host-responsive-container-sm-min(false) {
   .sky-action-button {
     padding: $sky-padding-triple $sky-padding-double;
     margin: 0;
@@ -89,7 +43,7 @@
   }
 }
 
-@include sky-theme-modern {
+.sky-theme-modern {
   .sky-action-button {
     display: flex;
     flex-flow: row nowrap;
@@ -104,7 +58,7 @@
     }
   }
 
-  @include sky-host-responsive-container-xs-min() {
+  @include sky-host-responsive-container-xs-min(false) {
     .sky-action-button {
       padding: $sky-theme-modern-padding-even-xl;
       margin: 0;
@@ -112,7 +66,7 @@
     }
   }
 
-  @include sky-host-responsive-container-sm-min() {
+  @include sky-host-responsive-container-sm-min(false) {
     .sky-action-button {
       padding: $sky-theme-modern-padding-even-xl;
       margin: 0;

--- a/src/app/public/modules/action-button/action-button.component.ts
+++ b/src/app/public/modules/action-button/action-button.component.ts
@@ -2,7 +2,8 @@ import {
   Component,
   EventEmitter,
   Input,
-  Output
+  Output,
+  ViewEncapsulation
 } from '@angular/core';
 
 import {
@@ -15,7 +16,8 @@ import {
 @Component({
   selector: 'sky-action-button',
   styleUrls: ['./action-button.component.scss'],
-  templateUrl: './action-button.component.html'
+  templateUrl: './action-button.component.html',
+  encapsulation: ViewEncapsulation.None
 })
 export class SkyActionButtonComponent {
 


### PR DESCRIPTION
`clean-css` is removing spaces from `:host-selector()`, which destroys the margins for action buttons inside a container. This fix removes view encapsulation and re-organizes the CSS declarations so we don't nee to rely on `:host-selector()` anymore.